### PR TITLE
fix  @JsonProperty("message-timestamp")

### DIFF
--- a/src/main/java/com/nexmo/quickstart/sms/IncomingDlrPayload.java
+++ b/src/main/java/com/nexmo/quickstart/sms/IncomingDlrPayload.java
@@ -73,7 +73,7 @@ public class IncomingDlrPayload {
         return errCode;
     }
 
-    @JsonProperty("messageTimestamp")
+    @JsonProperty("message-timestamp")
     public String getMessageTimestamp() {
         return messageTimestamp;
     }


### PR DESCRIPTION
based on this example in [the official doc ](https://developer.nexmo.com/messaging/sms/code-snippets/delivery-receipts#try-it-out) its `message-timestamp` and not `messageTimestamp`