### PR TITLE
Update build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ values into environment variables, so you'll probably want to use a tool like
 [Foreman](https://github.com/ddollar/foreman) to run your code like this:
 
 ```sh
-foreman run java -cp build/libs/nexmo-java-quickstart-with-dependencies.jar CLASS
+foreman run java -cp build/libs/nexmo-java-code-snippets-with-dependencies.jar CLASS
 ```
 
 So to run the OutboundTextToSpeechExample class, you would run the following:

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
+plugins {
+    id 'java'
+}
 
-apply plugin: 'java'
-
-// Uncomment the following lines to work with a local copy of nexmo-java:
+// Uncomment the following lines to work with a local copy of vonage-java-sdk:
 // configurations.all {
 //    resolutionStrategy.dependencySubstitution {
 //        substitute module("com.nexmo:client") with project(":client")
@@ -13,16 +14,17 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 
-    compile 'com.nexmo:client:5.2.0'
-    compile "com.sparkjava:spark-core:2.6.0"
-    compile 'javax.xml.bind:jaxb-api:2.3.0'
+    implementation 'com.nexmo:client:5.6.0'
+    implementation "com.sparkjava:spark-core:2.6.0"
+    implementation 'javax.xml.bind:jaxb-api:2.3.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9'
 }
 
-task fatJar(type: Jar, dependsOn:configurations.runtime) {
-    baseName = project.name + '-with-dependencies'
-    from { configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) } }
+task fatJar(type: Jar, dependsOn:configurations.runtimeClasspath) {
+    archiveBaseName = project.name + '-with-dependencies'
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
 assemble.dependsOn fatJar


### PR DESCRIPTION
This updates the dependencies to match with the Vonage version of this repo, and adds in the `jackson-databind` dependency. 

This should be merged _after_ nexmo:client 5.6.0 is deployed, as I also made that the dependency since 5.6.0 fixes an issue with application auth. 