### PR TITLE
[Security] Properly verify the JWT signature.

### DIFF
--- a/src/main/java/com/vonage/quickstart/jwt/ValidateInboundJwt.java
+++ b/src/main/java/com/vonage/quickstart/jwt/ValidateInboundJwt.java
@@ -41,7 +41,7 @@ public class ValidateInboundJwt {
                                 .getBytes(StandardCharsets.UTF_8))
                                 .build();
                 String token = req.headers("Authorization").substring(7);
-                parser.parse(token);
+                parser.parseClaimsJws(token);
                 res.status(204);
             }
             catch (Exception ex){


### PR DESCRIPTION
The `parse` method does not verify the signature of a JWT.
So it e.g. accepts a token like this:
`someBase64EncodedHeader.someBase64EncodedClaims.`
Notice that it accepts a token without a signature.
By using the `parseClaimsJws` method instead, the signature is correctly verified.