### PR TITLE
Add Messages v1 samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,5 @@ build
 
 *.key
 
-.env
+*.env
 .DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 plugins {
     id 'java'
 }
@@ -17,15 +16,15 @@ repositories {
 dependencies {
     testImplementation 'junit:junit:4.13.2'
 
-    implementation 'com.vonage:client:[6.1.0,7.0.0)'
+    implementation 'com.vonage:client:6.+'
     implementation 'com.nexmo:jwt:1.0.1'
     implementation 'com.sparkjava:spark-core:2.9.3'
     implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 task fatJar(type: Jar, dependsOn:configurations.runtimeClasspath) {

--- a/src/main/java/com/vonage/quickstart/jwt/ValidateInboundJwt.java
+++ b/src/main/java/com/vonage/quickstart/jwt/ValidateInboundJwt.java
@@ -45,7 +45,7 @@ public class ValidateInboundJwt {
                 res.status(204);
             }
             catch (Exception ex){
-                System.out.println(ex.toString());
+                System.out.println(ex);
                 res.status(401);
             }
             return "";

--- a/src/main/java/com/vonage/quickstart/messages/messenger/SendMessengerAudio.java
+++ b/src/main/java/com/vonage/quickstart/messages/messenger/SendMessengerAudio.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.messenger;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.messenger.MessengerAudioRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendMessengerAudio {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String FROM_ID = envVar("FROM_ID");
+		String TO_ID = envVar("TO_ID");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = MessengerAudioRequest.builder()
+				.from(FROM_ID).to(TO_ID)
+				.url("https://file-examples.com/storage/fee788409562ada83b58ed5/2017/11/file_example_MP3_1MG.mp3")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: " + response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default:
+					throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/messenger/SendMessengerFile.java
+++ b/src/main/java/com/vonage/quickstart/messages/messenger/SendMessengerFile.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.messenger;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.messenger.MessengerFileRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendMessengerFile {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String FROM_ID = envVar("FROM_ID");
+		String TO_ID = envVar("TO_ID");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = MessengerFileRequest.builder()
+				.from(FROM_ID).to(TO_ID)
+				.url("https://file-examples.com/storage/fee788409562ada83b58ed5/2017/10/file-sample_150kB.pdf")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: " + response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default:
+					throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/messenger/SendMessengerImage.java
+++ b/src/main/java/com/vonage/quickstart/messages/messenger/SendMessengerImage.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.messenger;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.messenger.MessengerImageRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendMessengerImage {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String FROM_ID = envVar("FROM_ID");
+		String TO_ID = envVar("TO_ID");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = MessengerImageRequest.builder()
+				.from(FROM_ID).to(TO_ID)
+				.url("https://file-examples.com/wp-content/uploads/2017/10/file_example_JPG_500kB.jpg")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: " + response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default:
+					throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/messenger/SendMessengerText.java
+++ b/src/main/java/com/vonage/quickstart/messages/messenger/SendMessengerText.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.messenger;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.messenger.Category;
+import com.vonage.client.messages.messenger.MessengerTextRequest;
+import com.vonage.client.messages.messenger.Tag;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendMessengerText {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String FROM_ID = envVar("FROM_ID");
+		String TO_ID = envVar("TO_ID");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = MessengerTextRequest.builder()
+				.from(FROM_ID).to(TO_ID)
+				.text("Reminder of your event, which starts in 30 minutes.")
+				.category(Category.MESSAGE_TAG)
+				.tag(Tag.CONFIRMED_EVENT_UPDATE)
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: " + response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default:
+					throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/messenger/SendMessengerVideo.java
+++ b/src/main/java/com/vonage/quickstart/messages/messenger/SendMessengerVideo.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.messenger;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.messenger.MessengerVideoRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendMessengerVideo {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String FROM_ID = envVar("FROM_ID");
+		String TO_ID = envVar("TO_ID");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = MessengerVideoRequest.builder()
+				.from(FROM_ID).to(TO_ID)
+				.url("https://file-examples.com/storage/fee788409562ada83b58ed5/2017/04/file_example_MP4_640_3MG.mp4")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: " + response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default:
+					throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/mms/SendMmsAudio.java
+++ b/src/main/java/com/vonage/quickstart/messages/mms/SendMmsAudio.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.mms;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.mms.MmsAudioRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendMmsAudio {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String FROM_NUMBER = envVar("FROM_NUMBER");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = MmsAudioRequest.builder()
+				.from(FROM_NUMBER).to(TO_NUMBER)
+				.url("https://file-examples.com/wp-content/uploads/2017/11/file_example_WAV_1MG.wav")
+				.caption("Accompanying message (optional)")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/mms/SendMmsImage.java
+++ b/src/main/java/com/vonage/quickstart/messages/mms/SendMmsImage.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.mms;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.mms.MmsImageRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendMmsImage {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String FROM_NUMBER = envVar("FROM_NUMBER");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = MmsImageRequest.builder()
+				.from(FROM_NUMBER).to(TO_NUMBER)
+				.url("https://file-examples.com/wp-content/uploads/2017/10/file_example_GIF_500kB.gif")
+				.caption("Accompanying message (optional)")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/mms/SendMmsVcard.java
+++ b/src/main/java/com/vonage/quickstart/messages/mms/SendMmsVcard.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.mms;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.mms.MmsVcardRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendMmsVcard {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String FROM_NUMBER = envVar("FROM_NUMBER");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = MmsVcardRequest.builder()
+				.from(FROM_NUMBER).to(TO_NUMBER)
+				.url("https://www.phpclasses.org/browse/download/1/file/5543/name/sample.vcf")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/mms/SendMmsVideo.java
+++ b/src/main/java/com/vonage/quickstart/messages/mms/SendMmsVideo.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.mms;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.mms.MmsVideoRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendMmsVideo {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String FROM_NUMBER = envVar("FROM_NUMBER");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = MmsVideoRequest.builder()
+				.from(FROM_NUMBER).to(TO_NUMBER)
+				.url("https://file-examples.com/storage/fee788409562ada83b58ed5/2017/04/file_example_MP4_640_3MG.mp4")
+				.caption("Accompanying message (optional)")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/sms/SendSmsText.java
+++ b/src/main/java/com/vonage/quickstart/messages/sms/SendSmsText.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.sms;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.sms.*;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendSmsText {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String FROM_NUMBER = envVar("FROM_NUMBER");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = SmsTextRequest.builder()
+				.from(FROM_NUMBER).to(TO_NUMBER)
+				.text("Hello from Vonage!")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/viber/SendViberImage.java
+++ b/src/main/java/com/vonage/quickstart/messages/viber/SendViberImage.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.viber;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.viber.ViberImageRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendViberImage {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String FROM_ID = envVar("FROM_ID");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = ViberImageRequest.builder()
+				.from(FROM_ID).to(TO_NUMBER)
+				.url("https://file-examples.com/wp-content/uploads/2017/10/file_example_JPG_500kB.jpg")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/viber/SendViberText.java
+++ b/src/main/java/com/vonage/quickstart/messages/viber/SendViberText.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.viber;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.viber.Category;
+import com.vonage.client.messages.viber.ViberTextRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendViberText {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String FROM_ID = envVar("FROM_ID");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = ViberTextRequest.builder()
+				.from(FROM_ID).to(TO_NUMBER)
+				.text("Don't miss out on our latest offers!")
+				.category(Category.PROMOTION)
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappAudio.java
+++ b/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappAudio.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.whatsapp;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.whatsapp.WhatsappAudioRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendWhatsappAudio {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String VONAGE_WHATSAPP_NUMBER = envVar("VONAGE_WHATSAPP_NUMBER");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = WhatsappAudioRequest.builder()
+				.from(VONAGE_WHATSAPP_NUMBER).to(TO_NUMBER)
+				.url("https://file-examples.com/storage/fee788409562ada83b58ed5/2017/11/file_example_MP3_1MG.mp3")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappContact.java
+++ b/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappContact.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.whatsapp;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.whatsapp.WhatsappCustomRequest;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendWhatsappContact {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String VONAGE_WHATSAPP_NUMBER = envVar("VONAGE_WHATSAPP_NUMBER");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = WhatsappCustomRequest.builder()
+				.from(VONAGE_WHATSAPP_NUMBER).to(TO_NUMBER)
+				.custom(Map.of(
+					"type", "contacts",
+					"contacts", List.of(Map.of(
+						"addresses", List.of(
+							Map.of(
+								"city", "Menlo Park",
+								"country", "United States",
+								"state", "CA",
+								"country_code", "us",
+								"street", "1 Hacker Way",
+								"type", "HOME",
+								"zip", "94025"
+							),
+							Map.of(
+								"city", "Menlo Park",
+								"country", "United States",
+								"state", "CA",
+								"country_code", "us",
+								"street", "200 Jefferson Dr",
+								"type", "WORK",
+								"zip", "94025"
+							)
+						),
+						"birthday", "2012-08-18",
+						"emails", List.of(
+							Map.of(
+								"email", "test@fb.com",
+								"type", "WORK"
+							),
+							Map.of(
+								"email", "test@whatsapp.com",
+								"type", "WORK"
+							)
+						),
+						Map.of("name", Map.of(
+							"first_name", "Jayden",
+							"last_name", "Smith",
+							"formatted_name", "J. Smith"
+						)),
+						Map.of("org", Map.of(
+							"company", "WhatsApp",
+							"department", "Design",
+							"title", "Manager"
+						)),
+						Map.of("phones", List.of(
+							Map.of(
+								"phone", "+1 (940) 555-1234",
+								"type", "HOME"
+							),
+							Map.of(
+								"phone", "+1 (650) 555-1234",
+								"type", "WORK",
+								"wa_id", "16505551234"
+							)
+						)),
+						Map.of("urls", List.of(
+							Map.of(
+								"url", "https://www.facebook.com",
+								"type", "WORK"
+							)
+						))
+					))
+				))
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappFile.java
+++ b/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappFile.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.whatsapp;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.whatsapp.WhatsappFileRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendWhatsappFile {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String VONAGE_WHATSAPP_NUMBER = envVar("VONAGE_WHATSAPP_NUMBER");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = WhatsappFileRequest.builder()
+				.from(VONAGE_WHATSAPP_NUMBER).to(TO_NUMBER)
+				.url("https://file-examples.com/storage/fee788409562ada83b58ed5/2017/10/file-sample_150kB.pdf")
+				.caption("Accompanying message (optional)")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappImage.java
+++ b/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappImage.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.whatsapp;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.whatsapp.WhatsappImageRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendWhatsappImage {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String VONAGE_WHATSAPP_NUMBER = envVar("VONAGE_WHATSAPP_NUMBER");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = WhatsappImageRequest.builder()
+				.from(VONAGE_WHATSAPP_NUMBER).to(TO_NUMBER)
+				.url("https://file-examples.com/wp-content/uploads/2017/10/file_example_JPG_500kB.jpg")
+				.caption("Accompanying message (optional)")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappLocation.java
+++ b/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappLocation.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.whatsapp;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.whatsapp.WhatsappCustomRequest;
+
+import java.util.Map;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendWhatsappLocation {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String VONAGE_WHATSAPP_NUMBER = envVar("VONAGE_WHATSAPP_NUMBER");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = WhatsappCustomRequest.builder()
+				.from(VONAGE_WHATSAPP_NUMBER).to(TO_NUMBER)
+				.custom(Map.of(
+					"type", "location",
+					"location", Map.of(
+						"longitude", "-122.425332",
+						"latitude", "37.758056",
+						"name", "Facebook HQ",
+						"address", "1 Hacker Way, Menlo Park, CA 94025"
+					)
+				))
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappTemplate.java
+++ b/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappTemplate.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.whatsapp;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.whatsapp.Policy;
+import com.vonage.client.messages.whatsapp.WhatsappTemplateRequest;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendWhatsappTemplate {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String VONAGE_WHATSAPP_NUMBER = envVar("VONAGE_WHATSAPP_NUMBER");
+		String TO_NUMBER = envVar("TO_NUMBER");
+		String WHATSAPP_TEMPLATE_NAMESPACE = envVar("WHATSAPP_TEMPLATE_NAMESPACE");
+		String WHATSAPP_TEMPLATE_NAME = envVar("WHATSAPP_TEMPLATE_NAMES");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = WhatsappTemplateRequest.builder()
+				.from(VONAGE_WHATSAPP_NUMBER).to(TO_NUMBER)
+				.policy(Policy.DETERMINISTIC).locale("en-GB")
+				.name(WHATSAPP_TEMPLATE_NAMESPACE+':'+WHATSAPP_TEMPLATE_NAME)
+				.parameters(List.of(
+					Map.of("default", "Vonage Verification"),
+					Map.of("default", "64873"),
+					Map.of("default", "10")
+				))
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappText.java
+++ b/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappText.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.whatsapp;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.whatsapp.WhatsappTextRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendWhatsappText {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String VONAGE_WHATSAPP_NUMBER = envVar("VONAGE_WHATSAPP_NUMBER");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = WhatsappTextRequest.builder()
+				.from(VONAGE_WHATSAPP_NUMBER).to(TO_NUMBER)
+				.text("Hello from Vonage!")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappVideo.java
+++ b/src/main/java/com/vonage/quickstart/messages/whatsapp/SendWhatsappVideo.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.whatsapp;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.whatsapp.WhatsappVideoRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendWhatsappVideo {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		String VONAGE_APPLICATION_ID = envVar("VONAGE_APPLICATION_ID");
+		String VONAGE_PRIVATE_KEY_PATH = envVar("VONAGE_PRIVATE_KEY_PATH");
+		String VONAGE_WHATSAPP_NUMBER = envVar("VONAGE_WHATSAPP_NUMBER");
+		String TO_NUMBER = envVar("TO_NUMBER");
+
+		VonageClient client = VonageClient.builder()
+				.applicationId(VONAGE_APPLICATION_ID)
+				.privateKeyPath(VONAGE_PRIVATE_KEY_PATH)
+				.build();
+
+		var message = WhatsappVideoRequest.builder()
+				.from(VONAGE_WHATSAPP_NUMBER).to(TO_NUMBER)
+				.url("https://file-examples.com/storage/fee788409562ada83b58ed5/2017/04/file_example_MP4_640_3MG.mp4")
+				.caption("Accompanying message (optional)")
+				.build();
+
+		try {
+			var response = client.getMessagesClient().sendMessage(message);
+			System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+		}
+		catch (MessageResponseException mrx) {
+			switch (mrx.getStatusCode()) {
+				default: throw mrx;
+				case 401: // Bad credentials
+					throw new IllegalStateException(mrx.getTitle(), mrx);
+				case 402: // Low balance
+					client.getAccountClient().topUp("transactionID");
+					break;
+				case 429: // Rate limit
+					Thread.sleep(12_000);
+					break;
+				case 422: // Invalid
+					System.out.println(mrx.getDetail());
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/com/vonage/quickstart/numbers/NumberLifecycle.java
+++ b/src/main/java/com/vonage/quickstart/numbers/NumberLifecycle.java
@@ -53,7 +53,7 @@ public class NumberLifecycle {
             client.buyNumber(country, availableNumber.getMsisdn());
             System.out.println("❤️ Bought number.");
 
-            Thread.currentThread().sleep(1000);
+            Thread.sleep(1000);
             ListNumbersFilter filter = new ListNumbersFilter();
             filter.setPattern(availableNumber.getMsisdn());
             filter.setSearchPattern(SearchPattern.STARTS_WITH);

--- a/src/main/java/com/vonage/quickstart/sms/IncomingDlrPayload.java
+++ b/src/main/java/com/vonage/quickstart/sms/IncomingDlrPayload.java
@@ -93,7 +93,7 @@ public class IncomingDlrPayload {
                 '}';
     }
 
-    private static ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public static IncomingDlrPayload fromJson(byte[] bytes) throws IOException {
         return objectMapper.readValue(bytes, IncomingDlrPayload.class);

--- a/src/main/java/com/vonage/quickstart/sms/IncomingSmsPayload.java
+++ b/src/main/java/com/vonage/quickstart/sms/IncomingSmsPayload.java
@@ -79,7 +79,7 @@ public class IncomingSmsPayload {
         return messageTimestamp;
     }
 
-    private static ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public static IncomingSmsPayload fromJson(byte[] bytes) throws IOException {
         return objectMapper.readValue(bytes, IncomingSmsPayload.class);

--- a/src/main/java/com/vonage/quickstart/sms/ReceiveSignedSms.java
+++ b/src/main/java/com/vonage/quickstart/sms/ReceiveSignedSms.java
@@ -21,7 +21,6 @@
  */
 package com.vonage.quickstart.sms;
 
-import com.vonage.client.incoming.MessageEvent;
 import com.vonage.client.auth.RequestSigning;
 import com.vonage.client.auth.hashutils.HashUtil;
 

--- a/src/main/java/com/vonage/quickstart/voice/SendTalkToCall.java
+++ b/src/main/java/com/vonage/quickstart/voice/SendTalkToCall.java
@@ -25,7 +25,6 @@ import com.vonage.client.VonageClient;
 import com.vonage.client.voice.Call;
 import com.vonage.client.voice.CallEvent;
 import com.vonage.client.voice.TextToSpeechLanguage;
-import com.vonage.client.voice.VoiceName;
 
 import static com.vonage.quickstart.Util.configureLogging;
 import static com.vonage.quickstart.Util.envVar;


### PR DESCRIPTION
This PR adds code samples for all possible message types supported by the [Messages v1 API](https://developer.vonage.com/api/messages-olympus) in the [Java SDK](https://github.com/Vonage/vonage-java-sdk).