### PR TITLE
Added Messages sandbox for demos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'com.vonage:jwt:latest.integration'
     implementation 'com.sparkjava:spark-core:2.9.4'
     implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/vonage/quickstart/messages/sandbox/SendMmsImage.java
+++ b/src/main/java/com/vonage/quickstart/messages/sandbox/SendMmsImage.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.sandbox;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponse;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.MessagesClient;
+import com.vonage.client.messages.mms.MmsImageRequest;
+
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendMmsImage {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		System.out.println(VonageClient.builder()
+				.apiKey(envVar("VONAGE_API_KEY"))
+				.apiSecret(envVar("VONAGE_API_SECRET"))
+				.build()
+				.getMessagesClient()
+				.sendMessage(MmsImageRequest.builder()
+					.from(envVar("FROM_NUMBER"))
+					.to(envVar("TO_NUMBER"))
+					.url("https://lastfm.freetls.fastly.net/i/u/770x0/a21ed806c65618ea1e7a6c8b4abf0402.jpg")
+					.caption("Fluttershy")
+					.build()
+				).getMessageUuid()
+		);
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/sandbox/SendSmsText.java
+++ b/src/main/java/com/vonage/quickstart/messages/sandbox/SendSmsText.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.sandbox;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponse;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.MessagesClient;
+import com.vonage.client.messages.sms.SmsTextRequest;
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendSmsText {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		System.out.println(VonageClient.builder()
+				.apiKey(envVar("VONAGE_API_KEY"))
+				.apiSecret(envVar("VONAGE_API_SECRET"))
+				.build()
+				.getMessagesClient()
+				.sendMessage(SmsTextRequest.builder()
+					.from(envVar("FROM_NUMBER"))
+					.to(envVar("TO_NUMBER"))
+					.text("Hello, "+System.getenv("NAME"))
+					.build()
+				).getMessageUuid()
+		);
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/sandbox/SendWhatsappAudio.java
+++ b/src/main/java/com/vonage/quickstart/messages/sandbox/SendWhatsappAudio.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.sandbox;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponse;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.MessagesClient;
+import com.vonage.client.messages.whatsapp.WhatsappAudioRequest;
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendWhatsappAudio {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		System.out.println(VonageClient.builder()
+				.apiKey(envVar("VONAGE_API_KEY"))
+				.apiSecret(envVar("VONAGE_API_SECRET"))
+				.build()
+				.getMessagesClient()
+				.useSandboxEndpoint()
+				.sendMessage(WhatsappAudioRequest.builder()
+					.from(envVar("VONAGE_WHATSAPP_NUMBER"))
+					.to(envVar("TO_NUMBER"))
+					.url("https://file-examples.com/storage/fee788409562ada83b58ed5/2017/11/file_example_MP3_1MG.mp3")
+					.build()
+				).getMessageUuid()
+		);
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/sandbox/SendWhatsappContact.java
+++ b/src/main/java/com/vonage/quickstart/messages/sandbox/SendWhatsappContact.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.sandbox;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponse;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.MessagesClient;
+import com.vonage.client.messages.whatsapp.WhatsappCustomRequest;
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+import java.util.List;
+import java.util.Map;
+
+public class SendWhatsappContact {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		System.out.println(VonageClient.builder()
+				.apiKey(envVar("VONAGE_API_KEY"))
+				.apiSecret(envVar("VONAGE_API_SECRET"))
+				.build()
+				.getMessagesClient()
+				.useSandboxEndpoint()
+				.sendMessage(WhatsappCustomRequest.builder()
+					.from(envVar("VONAGE_WHATSAPP_NUMBER"))
+					.to(envVar("TO_NUMBER"))
+					.custom(Map.of(
+						"type", "contacts",
+						"contacts", List.of(Map.of(
+							"addresses", List.of(
+								Map.of(
+									"city", "Menlo Park",
+									"country", "United States",
+									"state", "CA",
+									"country_code", "us",
+									"street", "1 Hacker Way",
+									"type", "HOME",
+									"zip", "94025"
+								),
+								Map.of(
+									"city", "Menlo Park",
+									"country", "United States",
+									"state", "CA",
+									"country_code", "us",
+									"street", "200 Jefferson Dr",
+									"type", "WORK",
+									"zip", "94025"
+								)
+							),
+							"birthday", "2012-08-18",
+							"emails", List.of(
+								Map.of(
+									"email", "test@fb.com",
+									"type", "WORK"
+								),
+								Map.of(
+									"email", "test@whatsapp.com",
+									"type", "WORK"
+								)
+							),
+							Map.of("name", Map.of(
+								"first_name", "Jayden",
+								"last_name", "Smith",
+								"formatted_name", "J. Smith"
+							)),
+							Map.of("org", Map.of(
+								"company", "WhatsApp",
+								"department", "Design",
+								"title", "Manager"
+							)),
+							Map.of("phones", List.of(
+								Map.of(
+									"phone", "+1 (940) 555-1234",
+									"type", "HOME"
+								),
+								Map.of(
+									"phone", "+1 (650) 555-1234",
+									"type", "WORK",
+									"wa_id", "16505551234"
+								)
+							)),
+							Map.of("urls", List.of(
+								Map.of(
+									"url", "https://www.facebook.com",
+									"type", "WORK"
+								)
+							))
+						))
+				))
+				.build()
+			).getMessageUuid()
+		);
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/sandbox/SendWhatsappImage.java
+++ b/src/main/java/com/vonage/quickstart/messages/sandbox/SendWhatsappImage.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.sandbox;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponse;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.MessagesClient;
+import com.vonage.client.messages.whatsapp.WhatsappImageRequest;
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendWhatsappImage {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		VonageClient client = VonageClient.builder()
+				.apiKey(envVar("VONAGE_API_KEY"))
+				.apiSecret(envVar("VONAGE_API_SECRET"))
+				.build();
+
+		MessagesClient messagesClient = client.getMessagesClient().useSandboxEndpoint();
+
+		var message = WhatsappImageRequest.builder()
+				.from(envVar("VONAGE_WHATSAPP_NUMBER"))
+				.to(envVar("TO_NUMBER"))
+				.url("https://lastfm.freetls.fastly.net/i/u/770x0/a21ed806c65618ea1e7a6c8b4abf0402.jpg")
+				.caption("Fluttershy")
+				.build();
+
+		MessageResponse response = messagesClient.sendMessage(message);
+		System.out.println("Message sent successfully. ID: "+response.getMessageUuid());
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/sandbox/SendWhatsappLocation.java
+++ b/src/main/java/com/vonage/quickstart/messages/sandbox/SendWhatsappLocation.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.sandbox;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponse;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.MessagesClient;
+import com.vonage.client.messages.whatsapp.WhatsappCustomRequest;
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+import java.util.Map;
+
+public class SendWhatsappLocation {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		System.out.println(VonageClient.builder()
+				.apiKey(envVar("VONAGE_API_KEY"))
+				.apiSecret(envVar("VONAGE_API_SECRET"))
+				.build()
+				.getMessagesClient()
+				.useSandboxEndpoint()
+				.sendMessage(WhatsappCustomRequest.builder()
+					.custom(Map.of(
+						"type", "location",
+						"location", Map.of(
+							"longitude", "-122.425332",
+							"latitude", "37.758056",
+							"name", "Facebook HQ",
+							"address", "1 Hacker Way, Menlo Park, CA 94025"
+						)
+					))
+					.build()
+				).getMessageUuid()
+		);
+	}
+}

--- a/src/main/java/com/vonage/quickstart/messages/sandbox/SendWhatsappText.java
+++ b/src/main/java/com/vonage/quickstart/messages/sandbox/SendWhatsappText.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright  2022 Vonage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.vonage.quickstart.messages.sandbox;
+
+import com.vonage.client.VonageClient;
+import com.vonage.client.messages.MessageResponse;
+import com.vonage.client.messages.MessageResponseException;
+import com.vonage.client.messages.MessagesClient;
+import com.vonage.client.messages.whatsapp.WhatsappTextRequest;
+import static com.vonage.quickstart.Util.configureLogging;
+import static com.vonage.quickstart.Util.envVar;
+
+public class SendWhatsappText {
+
+	public static void main(String[] args) throws Exception {
+		configureLogging();
+
+		System.out.println(VonageClient.builder()
+				.apiKey(envVar("VONAGE_API_KEY"))
+				.apiSecret(envVar("VONAGE_API_SECRET"))
+				.build()
+				.getMessagesClient()
+				.useSandboxEndpoint()
+				.sendMessage(WhatsappTextRequest.builder()
+					.from(envVar("VONAGE_WHATSAPP_NUMBER"))
+					.to(envVar("TO_NUMBER"))
+					.text("Hello from Vonage, "+System.getenv("NAME"))
+					.build()
+				).getMessageUuid()
+		);
+	}
+}


### PR DESCRIPTION
This PR adds demos for the Messages API which can easily be used at events to quickly show the API working without having to modify the existing snippets. All configuration is located in the local `env.env` file, and uses the sandbox for convenience.